### PR TITLE
Add forked gcodeplot as submodule w readme update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gcodeplot"]
+	path = gcodeplot
+	url = https://github.com/TyGuy/gcodeplot.git

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ python --version
 pip install --user pipenv
 ```
 
-Clone this repo:
+Clone this repo (**NOTE: this project uses git submodules, so be sure to include the option below**):
 ```sh
-git clone https://github.com/TyGuy/atlas-axiom.git
+git clone --recurse-submodules https://github.com/TyGuy/atlas-axiom.git
 cd atlas-axiom
 ```
 
+As mentioned above, the project uses a submodule for the [gcodeplot](https://github.com/TyGuy/gcodeplot) library, which turns an image into GCode, and is forked from https://github.com/arpruss/gcodeplot (in case we need to make our own custom changes).
 
 ---
 


### PR DESCRIPTION
This adds https://github.com/TyGuy/gcodeplot as a submodule to this repo, which is a fork of https://github.com/arpruss/gcodeplot, so that we can make our own changes as needed. I think this would be a good library for doing gcode conversion of vector images (input requirements is a vector-based image).